### PR TITLE
Feature/install dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # Ignore ruby-version
 /.ruby-version
+
+# Ignore environment file.
+/.env

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@
 /.ruby-version
 
 # Ignore environment file.
-/.env
+/.env*

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 ruby '2.7.0'
 
+gem 'dotenv-rails', groups: [:development, :test]
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~>6.0.2'
 # Use postgresql as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     execjs (2.7.0)
     ffi (1.12.2)
@@ -194,6 +198,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   coffee-rails
+  dotenv-rails
   jbuilder
   jquery-rails
   line-bot-api

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,8 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+Dotenv::Railtie.load
+
 module RubyGettingStarted
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,4 +59,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.hosts << '.ngrok.io'
 end


### PR DESCRIPTION
## 実装の背景・目的

ngrokを使って、ローカル環境でBotのテストができるようにした。

## やったこと
-ngrokとdotenvをgemでインストール
- dotenvでenvファイルの読み込みを制限