### PR TITLE
application.rb内のDotenvの記述を無効化

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,9 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-Dotenv::Railtie.load
+if Rails.env.development? || Rails.env.test?
+  Dotenv::Railtie.load
+end
 
 module RubyGettingStarted
   class Application < Rails::Application


### PR DESCRIPTION
## 実装の背景・目的

本番環境の時はDotenvのgemが読み込まれないので、Application.rbに記述した、Dotenvに関する記述を読み込まないようにした。

## やったこと

・Application.rbのDotenvに関する記述を本番環境で無効化