### PR TITLE
検索ワードに応じてGiphyAPIから一つのgifを呼び出し、jpgに変換して返す

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,5 @@ gem 'sinatra'
 gem 'bootsnap', require: false
 
 gem 'listen', group: :development
+
+gem 'GiphyClient'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    GiphyClient (1.0.0)
+      json (~> 1.8, >= 1.8.3)
+      typhoeus (~> 1.0, >= 1.0.1)
     actioncable (6.0.2.1)
       actionpack (= 6.0.2.1)
       nio4r (~> 2.0)
@@ -73,6 +76,8 @@ GEM
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     execjs (2.7.0)
     ffi (1.12.2)
     globalid (0.4.2)
@@ -85,6 +90,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (1.8.6)
     line-bot-api (1.13.0)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -183,6 +189,8 @@ GEM
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -196,6 +204,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  GiphyClient
   bootsnap
   coffee-rails
   dotenv-rails

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -59,7 +59,6 @@ class WebhookController < ApplicationController
             result = api_instance.gifs_search_get(api_key, text, opts)
             gif = result.data[0]
             if gif
-              p convert_to_jpg(gif.images.preview_gif.url)
               message = {
                 type: 'image',
                 originalContentUrl: replace_to_https(convert_to_jpg(gif.images.fixed_height.url)),

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -43,7 +43,6 @@ class WebhookController < ApplicationController
           begin
             #Search Endpoint
             text = event.message['text']
-            jpg_url = replace_to_https(generate_jpg(text))
 
             api_instance = GiphyClient::DefaultApi.new
             api_key = ENV["GIPHY_API_KEY"]
@@ -82,22 +81,6 @@ class WebhookController < ApplicationController
       end
     }
     head :ok
-  end
-
-  def generate_jpg(text)
-    stripped_text = text.strip
-    case stripped_text
-    when '魚','fish','さかな','サカナ'
-      return Image::FISH
-    when '深海魚','しんかいぎょ','シンカイギョ'
-      return Image::DEEPFISH
-    when '悲しい','sad'
-      return Image::SAD
-    when '怒り','angry'
-      return Image::ANGRY
-    else
-      return ""
-    end
   end
 
   def replace_to_https(url)

--- a/app/models/Image.rb
+++ b/app/models/Image.rb
@@ -1,6 +1,0 @@
-module Image
-  FISH = "https://cookbiz.jp/soken/core/wp-content/uploads/2019/04/Fotolia_114908436_S.jpg"
-  DEEPFISH = "https://sp.hazardlab.jp/contents/post_info/2/4/6/24680/Blob.jpg"
-  SAD = "https://cdn.qetic.jp/wp-content/uploads/2019/12/12150212/music_191212_jindogg4.jpg"
-  ANGRY = "https://zbrush.zenryokuhp.com/bw_uploads/20110206.021.jpg"
-end


### PR DESCRIPTION
## 実装の背景・目的

検索ワードに応じてGiphyAPIから一つのgifを呼び出し、Bot側に送信する。
検索結果が出なかった場合には、その旨を伝えるメッセージを送信する
## やったこと
・GiphyClientのインポート
・検索結果の一つ目の要素から、画像を抜き出す。
・jpgへの変換処理(LINEの仕様で勝手に変更されるようになっているが、念の為実装)


## キャプチャ

![IMG_1998](https://user-images.githubusercontent.com/38806402/74895846-19d94e80-53d6-11ea-9c32-45e60d9645b5.PNG)


## 補足

- 補足事項があれば
- [ ] やることリストでも OK
