### PR TITLE
10つのgiphyオブジェクトから、giphyホームページへのリンクと画像を抜き出してhashに格納し、Botに送る

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -100,10 +100,10 @@ class WebhookController < ApplicationController
               }
 
             else
-               message = {
-                 type: 'text',
-                 text: "画像が見つからんかった\nスマンm(__)m"
-               }
+              message = {
+                type: 'text',
+                text: "画像が見つからんかった\nスマンm(__)m"
+              }
             end
 
           rescue GiphyClient::ApiError => e
@@ -111,7 +111,7 @@ class WebhookController < ApplicationController
           end
           client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
-           client.reply_message(event['replyToken'], default_message)
+          client.reply_message(event['replyToken'], default_message)
         end
       end
     }

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -68,25 +68,25 @@ class WebhookController < ApplicationController
             gifs = result.data
             if gifs&.count == 10
 
-            template_array = gifs.map do |gif|
-              {
-                'type':'bubble',
-                'hero':{
-                  'type':'image',
-                  'url':gif.images.fixed_height.url,
-                  'size':'full',
-                  'aspectMode':'cover',
-                  'action':{
-                    'type':'uri',
-                    'label':'View details',
-                    'uri':"#{gif.url}?openExternalBrowser=1",
-                    'altUri':{
-                      'desktop':"#{gif.url}?openExternalBrowser=1"
+              template_array = gifs.map do |gif|
+                {
+                  'type':'bubble',
+                  'hero':{
+                    'type':'image',
+                    'url':gif.images.fixed_height.url,
+                    'size':'full',
+                    'aspectMode':'cover',
+                    'action':{
+                      'type':'uri',
+                      'label':'View details',
+                      'uri':"#{gif.url}?openExternalBrowser=1",
+                      'altUri':{
+                        'desktop':"#{gif.url}?openExternalBrowser=1"
+                      }
                     }
                   }
                 }
-              }
-            end
+              end
 
               hash_flex_template = {
                 'type':'carousel',
@@ -99,12 +99,12 @@ class WebhookController < ApplicationController
                 contents: hash_flex_template
               }
 
-             else
+            else
                message = {
                  type: 'text',
                  text: "画像が見つからんかった\nスマンm(__)m"
                }
-             end
+            end
 
           rescue GiphyClient::ApiError => e
             puts "Exception when calling DefaultApi->gifs_search_get: #{e}"

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -79,7 +79,7 @@ class WebhookController < ApplicationController
                   'action':{
                     'type':'uri',
                     'label':'View details',
-                    'uri':gif.url+'?openExternalBrowser=1',
+                    'uri':"#{gif.url}?openExternalBrowser=1",
                     'altUri':{
                       'desktop':"#{gif.url}?openExternalBrowser=1"
                     }
@@ -95,7 +95,7 @@ class WebhookController < ApplicationController
 
               message = {
                 type: 'flex',
-                altText: '代官テキスト',
+                altText: '画像を読み込めませんでした。',
                 contents: hash_flex_template
               }
 

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -48,21 +48,67 @@ class WebhookController < ApplicationController
             api_key = ENV["GIPHY_API_KEY"]
 
             opts = {
-              limit: 1,
+              limit: 10,
               offset: 0,
               rating: "g",
               lang: "ja",
               fmt: "json"
             }
 
-            result = api_instance.gifs_search_get(api_key, text, opts)
-            gif = result.data[0]
-            if gif
-              message = {
-                type: 'image',
-                originalContentUrl: replace_to_https(convert_to_jpg(gif.images.fixed_height.url)),
-                previewImageUrl: replace_to_https(convert_to_jpg(gif.images.preview_gif.url))
+            template_json = {
+              'type':'bubble',
+              'hero':{
+                'type':'image',
+                'url':'',
+                'size':'full',
+                'aspectMode':'cover',
+                'action':{
+                  'type':'uri',
+                  'label':'View details',
+                  'uri':'',
+                  'altUri':{
+                    'desktop':''
+                  }
+                }
               }
+            }
+
+            result = api_instance.gifs_search_get(api_key, text, opts)
+            gifs = result.data
+            if gifs && gifs.count == 10
+
+            hash_flex_template = {
+              'type':'carousel',
+              'contents': []
+            }
+
+              gifs.each do |gif|
+                template_hash = {
+                  'type':'bubble',
+                  'hero':{
+                    'type':'image',
+                    'url':gif.images.fixed_height.url,
+                    'size':'full',
+                    'aspectMode':'cover',
+                    'action':{
+                      'type':'uri',
+                      'label':'View details',
+                      'uri':gif.url+'?openExternalBrowser=1',
+                      'altUri':{
+                        'desktop':gif.url+'?openExternalBrowser=1'
+                      }
+                    }
+                  }
+                }
+                hash_flex_template[:contents].push(template_hash)
+              end
+
+              message = {
+                type: 'flex',
+                altText: '代官テキスト',
+                contents: hash_flex_template
+              }
+
             else
               message = {
                 type: 'text',


### PR DESCRIPTION
## 実装の背景・目的
　GiphyAPIから検索ワードに応じたgifオブジェクト(APIデータ)を10個受け取り、その中から得た画像urlとGIF検索サービス(Giphy) のリンクをBotに送信する。
## やったこと
・フレックスメッセージを作るためのテンプレートハッシュを用意
・画像urlとGiphyへのリンクをハッシュに代入
## キャプチャ
![IMG_1999](https://user-images.githubusercontent.com/38806402/74924984-c9361580-5416-11ea-90dd-886da44c6099.PNG)


スクリーンショットなどがあれば

## 補足

- 補足事項があれば
- [ ] やることリストでも OK
