### PR TITLE
Botに表示するFlexMessageのハッシュを返すクラスとGiphyAPIを扱うクラスの切り出し

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -3,13 +3,6 @@ require 'line/bot'
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
 
-  def client
-    @client ||= Line::Bot::Client.new { |config|
-      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
-      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
-    }
-  end
-
   def callback
     body = request.body.read
     signature = request.env['HTTP_X_LINE_SIGNATURE']

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,5 +1,4 @@
 require 'line/bot'
-require 'pathname'
 
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
@@ -30,8 +29,8 @@ class WebhookController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           text = event.message['text']
-          giphy_client_manager = GiphyClientManager.new
-          message = giphy_client_manager.message_hash(text)
+          giphy_client_manager = GiphyClientManager.new(text)
+          message = giphy_client_manager.message_hash
           client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           client.reply_message(event['replyToken'], default_message)

--- a/app/models/flex_message_template.rb
+++ b/app/models/flex_message_template.rb
@@ -20,7 +20,7 @@ class FlexMessageTemplate
 
   def generate_divisional_flex_template(gif)
     url = replace_to_https(convert_to_jpg(gif.images.fixed_height.url))
-    uri = replace_to_https(convert_to_jpg(gif.url))
+    uri = replace_to_https(gif.url)
     {
       'type':'bubble',
       'hero':{

--- a/app/models/flex_message_template.rb
+++ b/app/models/flex_message_template.rb
@@ -1,8 +1,22 @@
 require 'pathname'
 
 class FlexMessageTemplate
-  def initialize
+  attr_reader :gifs
+  def initialize(gifs)
+    @gifs = gifs
   end
+
+  def generate_flex_template
+    template_array = gifs.map do |gif|
+      generate_divisional_flex_template(gif)
+    end
+    hash_flex_template = {
+      'type':'carousel',
+      'contents': template_array
+    }
+  end
+
+  private
 
   def generate_divisional_flex_template(gif)
     url = replace_to_https(convert_to_jpg(gif.images.fixed_height.url))
@@ -25,14 +39,6 @@ class FlexMessageTemplate
       }
     }
   end
-
-  def generate_flex_template(gifs)
-    gifs.map do |gif|
-      generate_divisional_flex_template(gif)
-    end
-  end
-
-  private
 
   def replace_to_https(url)
     url.sub(/http:/, 'https:')

--- a/app/models/flex_message_template.rb
+++ b/app/models/flex_message_template.rb
@@ -1,0 +1,37 @@
+class FlexMessageTemplate
+  def initialize
+  end
+
+  def generate_divisional_flex_template(gif)
+    url = replace_to_https(convert_to_jpg(gif.images.fixed_height.url))
+    uri = replace_to_https(convert_to_jpg(gif.url))
+    {
+      'type':'bubble',
+      'hero':{
+        'type':'image',
+        'url':url,
+        'size':'full',
+        'aspectMode':'cover',
+        'action':{
+          'type':'uri',
+          'label':'View details',
+          'uri':"#{uri}?openExternalBrowser=1",
+          'altUri':{
+            'desktop':"#{uri}?openExternalBrowser=1"
+          }
+       }
+      }
+    }
+  end
+
+  private
+
+  def replace_to_https(url)
+    url.sub(/http:/, 'https:')
+  end
+
+  def convert_to_jpg(url)
+    Pathname(url).sub_ext(".jpg").to_s
+  end
+
+end

--- a/app/models/flex_message_template.rb
+++ b/app/models/flex_message_template.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 class FlexMessageTemplate
   def initialize
   end
@@ -22,6 +24,12 @@ class FlexMessageTemplate
        }
       }
     }
+  end
+
+  def generate_flex_template(gifs)
+    gifs.map do |gif|
+      generate_divisional_flex_template(gif)
+    end
   end
 
   private

--- a/app/models/giphy_client_manager.rb
+++ b/app/models/giphy_client_manager.rb
@@ -2,7 +2,6 @@ require 'GiphyClient'
 
 class GiphyClientManager
   attr_reader :text
-  @@client = GiphyClient::DefaultApi.new
   APIKEY = ENV["GIPHY_API_KEY"]
   API_SEARCH_OPTIONS = {
     limit: 10,
@@ -16,23 +15,13 @@ class GiphyClientManager
     @text = text
   end
 
-  def self.client
-    @@client
-  end
-
   def message_hash
     begin
-      giphy_client = GiphyClientManager.client
+      giphy_client = GiphyClient::DefaultApi.new
       gifs = giphy_client.gifs_search_get(APIKEY, @text, API_SEARCH_OPTIONS).data
-      if gifs&.count == 10
-        flex_message = FlexMessageTemplate.new
-        template_array = gifs.map do |gif|
-          flex_message.generate_divisional_flex_template(gif)
-        end
-        hash_flex_template = {
-          'type':'carousel',
-          'contents': template_array
-        }
+      if gifs
+        flex_message = FlexMessageTemplate.new(gifs)
+        hash_flex_template = flex_message.generate_flex_template
         return {
           type: 'flex',
           altText: '画像を読み込めませんでした。',

--- a/app/models/giphy_client_manager.rb
+++ b/app/models/giphy_client_manager.rb
@@ -35,6 +35,10 @@ class GiphyClientManager
       end
     rescue GiphyClient::ApiError => e
       puts "Exception when calling DefaultApi->gifs_search_get: #{e}"
+        return {
+          type: 'text',
+          text: "検索がうまくいかんかった\nスマンm(__)m"
+        }
     end
   end
 

--- a/app/models/giphy_client_manager.rb
+++ b/app/models/giphy_client_manager.rb
@@ -1,0 +1,47 @@
+require 'GiphyClient'
+
+class GiphyClientManager
+  @@client = GiphyClient::DefaultApi.new
+  APIKEY = ENV["GIPHY_API_KEY"]
+  API_SEARCH_OPTIONS = {
+    limit: 10,
+    offset: 0,
+    rating: "g",
+    lang: "ja",
+    fmt: "json"
+  }
+
+  def self.client
+    @@client
+  end
+
+  def message_hash(text)
+    begin
+      giphy_client = GiphyClientManager.client
+      gifs = giphy_client.gifs_search_get(APIKEY, text, API_SEARCH_OPTIONS).data
+      if gifs&.count == 10
+        flex_message = FlexMessageTemplate.new
+        template_array = gifs.map do |gif|
+          flex_message.generate_divisional_flex_template(gif)
+        end
+        hash_flex_template = {
+          'type':'carousel',
+          'contents': template_array
+        }
+        return {
+          type: 'flex',
+          altText: '画像を読み込めませんでした。',
+          contents: hash_flex_template
+        }
+      else
+        return {
+          type: 'text',
+          text: "画像が見つからんかった\nスマンm(__)m"
+        }
+      end
+    rescue GiphyClient::ApiError => e
+      puts "Exception when calling DefaultApi->gifs_search_get: #{e}"
+    end
+  end
+
+end

--- a/app/models/giphy_client_manager.rb
+++ b/app/models/giphy_client_manager.rb
@@ -1,6 +1,7 @@
 require 'GiphyClient'
 
 class GiphyClientManager
+  attr_reader :text
   @@client = GiphyClient::DefaultApi.new
   APIKEY = ENV["GIPHY_API_KEY"]
   API_SEARCH_OPTIONS = {
@@ -11,14 +12,18 @@ class GiphyClientManager
     fmt: "json"
   }
 
+  def initialize(text)
+    @text = text
+  end
+
   def self.client
     @@client
   end
 
-  def message_hash(text)
+  def message_hash
     begin
       giphy_client = GiphyClientManager.client
-      gifs = giphy_client.gifs_search_get(APIKEY, text, API_SEARCH_OPTIONS).data
+      gifs = giphy_client.gifs_search_get(APIKEY, @text, API_SEARCH_OPTIONS).data
       if gifs&.count == 10
         flex_message = FlexMessageTemplate.new
         template_array = gifs.map do |gif|

--- a/app/models/line_client_manager.rb
+++ b/app/models/line_client_manager.rb
@@ -1,0 +1,36 @@
+class LineClientManager
+
+  def validate_signature(body, signature)
+    client.validate_signature(body, signature)
+  end
+
+  def request(body)
+    events = client.parse_events_from(body)
+    events.each { |event|
+      case event
+      when Line::Bot::Event::Message
+        default_message = {
+          type: 'text',
+          text: "そのメッセージには対応していないんや。\nスマン m(__)m"
+        }
+        case event.type
+        when Line::Bot::Event::MessageType::Text
+          text = event.message['text']
+          giphy_client_manager = GiphyClientManager.new(text)
+          message = giphy_client_manager.message_hash
+          client.reply_message(event['replyToken'], message)
+        when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
+          client.reply_message(event['replyToken'], default_message)
+        end
+      end
+    }
+  end
+
+  private
+  def client
+    @client ||= Line::Bot::Client.new { |config|
+      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    }
+  end
+end

--- a/app/models/line_client_manager.rb
+++ b/app/models/line_client_manager.rb
@@ -11,7 +11,7 @@ class LineClientManager
       when Line::Bot::Event::Message
         default_message = {
           type: 'text',
-          text: "そのメッセージには対応していないんや。\nスマン m(__)m"
+          text: "そのメッセージには対応していないんや。\nスマンm(__)m"
         }
         case event.type
         when Line::Bot::Event::MessageType::Text


### PR DESCRIPTION
## 実装の背景・目的
・リファクタリングを行なった。

## やったこと

・LINEBotに表示するフレックスメッセージのハッシュを生成するFlexMessageTemplateクラスの生成
・GiphyAPIの呼び出しを行う、GiphyApiManagerクラスを生成

## 補足
・FlexMessageのハッシュの一番上位概念である、containerの部分の生成をFlexMessageTemplateクラスに移譲できていない。
・GiphyAPIManagerクラスでクラスメソッドとして、インスタンスを返すような処理を定義しているが、正直必要ない気がしてきた。
